### PR TITLE
Process semiconductor qa text files

### DIFF
--- a/TextGeneration/Datageneration.py
+++ b/TextGeneration/Datageneration.py
@@ -146,11 +146,21 @@ async def input_text_process(text_content, source_file, chunk_index=0, total_chu
         user_prompt = user_prompts[prompt_index]
         
         # Format the prompt with the text content
-        formatted_prompt = user_prompt.format(
-            text_content=text_content,
-            source_file=source_file,
-            chunk_info=f"(Chunk {chunk_index + 1}/{total_chunks})" if total_chunks > 1 else ""
-        )
+        # Check if the prompt expects markdown_content or text_content
+        if '{markdown_content}' in user_prompt:
+            formatted_prompt = user_prompt.format(
+                markdown_content=text_content,
+                source_file=source_file,
+                chunk_info=f"(Chunk {chunk_index + 1}/{total_chunks})" if total_chunks > 1 else ""
+            )
+        elif '{text_content}' in user_prompt:
+            formatted_prompt = user_prompt.format(
+                text_content=text_content,
+                source_file=source_file,
+                chunk_info=f"(Chunk {chunk_index + 1}/{total_chunks})" if total_chunks > 1 else ""
+            )
+        else:
+            formatted_prompt = user_prompt
         
         # Generate response using appropriate backend
         if use_local and local_model_manager:


### PR DESCRIPTION
Add conditional formatting for prompt placeholders to resolve the `'markdown_content'` error.

The error occurred because the prompt template expected a `{markdown_content}` placeholder, but the code was only providing `text_content`. This change ensures the correct placeholder (`markdown_content` or `text_content`) is used based on the prompt's content.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3f31616-c8ab-4c63-a665-0ac0e4c32109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3f31616-c8ab-4c63-a665-0ac0e4c32109">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

